### PR TITLE
Add a filter to exclude files from being saved as attachments.

### DIFF
--- a/Helper/MailHelper.php
+++ b/Helper/MailHelper.php
@@ -230,6 +230,12 @@ class MailHelper extends Base
 
     public function saveAndUpload($task_id, &$attachment)
     {
+        $excludes=$this->configModel->get('mailmagik_exclude_files_pattern', '');
+        if ( $excludes != '') {
+            if ( preg_match('/' . $excludes . '/',$attachment->name) ) {
+                    return;
+                }
+            }
         $tmp_name =  $this->mktempdir($task_id) . $attachment->name;
         $attachment->setFilePath($tmp_name);
         if (!file_exists($tmp_name)) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -25,6 +25,7 @@ class Plugin extends Base
             'mailmagik_pref' => '2',
             'mailmagik_include_files_tasks' => '1',
             'mailmagik_include_files_comments' => '0',
+            'mailmagik_exclude_files_pattern' => '',
             'mailmagik_proto' => '/imap/ssl',
             'mailmagik_parse_via' => '1',
             'mailmagik_parsing_enable' => '0',

--- a/Template/config/config.php
+++ b/Template/config/config.php
@@ -71,13 +71,6 @@
         )) ?>
 
         <?= $this->render($checkbox, array(
-            'label'   => t('Include attachments when converting to task automatically.'),
-            'name'    => 'mailmagik_include_files_tasks',
-            'default' => '1',
-            'values'  => $values,
-        )) ?>
-
-        <?= $this->render($checkbox, array(
             'label'   => t('Send confirmation email to the task creator.'),
             'name'    => 'mailmagik_task_notify',
             'default' => '0',
@@ -85,7 +78,14 @@
         )) ?>
 
         <br/>
-        <p><strong><?= t('Comments') ?></strong></p>
+        <p><strong><?= t('Attachments') ?></strong></p>
+
+        <?= $this->render($checkbox, array(
+            'label'   => t('Include attachments when converting to task automatically.'),
+            'name'    => 'mailmagik_include_files_tasks',
+            'default' => '1',
+            'values'  => $values,
+        )) ?>
 
         <?= $this->render($checkbox, array(
             'label'   => t('Include attachments when converting to comment automatically.'),
@@ -93,6 +93,7 @@
             'default' => '1',
             'values'  => $values,
         )) ?>
+
         <?= $this->form->label(t('Pattern of files not to attach'),
                                'mailmagik_exclude_files_pattern') ?>
         <?= $this->form->text('mailmagik_exclude_files_pattern',

--- a/Template/config/config.php
+++ b/Template/config/config.php
@@ -93,6 +93,10 @@
             'default' => '1',
             'values'  => $values,
         )) ?>
+        <?= $this->form->label(t('Pattern of files not to attach'),
+                               'mailmagik_exclude_files_pattern') ?>
+        <?= $this->form->text('mailmagik_exclude_files_pattern',
+                              $values, $errors) ?>
     </fieldset>
     <fieldset>
         <legend><?= t('Task Emails') ?></legend>


### PR DESCRIPTION
This PR adds a field to allow for an exclusion pattern when saving files.  There are several examples of files one might not saved:

- PGP signatures
- Just normal email signatures
- PGP keys
- Mailing list gorp.

Right now I've implemented as a simple regex.  The /s are prepended and appended for the user, so just the pattern is required.